### PR TITLE
Fix css directory permissions

### DIFF
--- a/src/Service/CompilationService.php
+++ b/src/Service/CompilationService.php
@@ -244,7 +244,7 @@ class CompilationService {
         $targetFile = $scssFile->getPath() . '/' . str_replace('scss', 'css', $scssFile->getFilename());
         if (!empty($this->configs[$scssFile->getPath()])) {
           if (!is_dir($scssFile->getPath() . '/' . $this->configs[$scssFile->getPath()]['css_dir'])) {
-            mkdir($scssFile->getPath() . '/' . $this->configs[$scssFile->getPath()]['css_dir'], 0770, TRUE);
+            mkdir($scssFile->getPath() . '/' . $this->configs[$scssFile->getPath()]['css_dir'], 0755, TRUE);
           }
           $targetFile = $scssFile->getPath() . '/' . $this->configs[$scssFile->getPath()]['css_dir'] . '/' . str_replace('scss', 'css', $scssFile->getFilename());
         }


### PR DESCRIPTION
When the css directory within the theme resources doesn't exist then it is created with the missing read permissions for everyone. This leads to nginx being denied access to the compiled css files.