### PR TITLE
Fix dependencies for SassCommand

### DIFF
--- a/iq_scss_compiler.services.yml
+++ b/iq_scss_compiler.services.yml
@@ -4,4 +4,4 @@ services:
     arguments: ['@logger.factory']
   iq_scss_compiler.sass_commands:
     class: Drupal\iq_scss_compiler\Commands\SassCommands
-    arguments: ['@logger.factory']
+    arguments: ['@logger.factory', '@iq_scss_compiler.compilation_service']


### PR DESCRIPTION
Add iq_scss_compiler.compilation_service as dependency for SassCommand